### PR TITLE
fix: update data directory on time

### DIFF
--- a/app/src/main/java/com/osfans/trime/data/DataDirectoryChangeListener.kt
+++ b/app/src/main/java/com/osfans/trime/data/DataDirectoryChangeListener.kt
@@ -1,0 +1,20 @@
+package com.osfans.trime.data
+
+/**
+ * Do something when data directory change.
+ */
+object DataDirectoryChangeListener {
+
+    // listener list
+    val directoryChangeListeners = mutableListOf<DataDirectoryChangeListener.Listener>()
+
+    interface Listener {
+        fun onDataDirectoryChange()
+    }
+
+    fun addDirectoryChangeListener(directoryChangeListener: DataDirectoryChangeListener.Listener) {
+        directoryChangeListeners.add(directoryChangeListener)
+    }
+    // do not remove
+    // 在 directoryChangeListeners 中存放单例类的情况下，不应该尝试调用remove，会导致ConcurrentModificationException
+}

--- a/app/src/main/java/com/osfans/trime/data/DataManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/DataManager.kt
@@ -6,20 +6,24 @@ import com.osfans.trime.util.Const
 import timber.log.Timber
 import java.io.File
 
-object DataManager {
+object DataManager : DataDirectoryChangeListener.Listener {
     private val prefs get() = AppPrefs.defaultInstance()
 
     val defaultDataDirectory = File(PathUtils.getExternalStoragePath(), "rime")
 
     @JvmStatic
-    val sharedDataDir = File(prefs.profile.sharedDataDir)
+    var sharedDataDir = File(prefs.profile.sharedDataDir)
 
     @JvmStatic
-    val userDataDir = File(prefs.profile.userDataDir)
+    var userDataDir = File(prefs.profile.userDataDir)
     val customDefault = File(sharedDataDir, "default.custom.yaml")
 
     private val stagingDir = File(userDataDir, "build")
     private val prebuiltDataDir = File(sharedDataDir, "build")
+
+    init {
+        DataDirectoryChangeListener.addDirectoryChangeListener(this)
+    }
 
     sealed class Diff {
         object New : Diff()
@@ -79,5 +83,13 @@ object DataManager {
         }
 
         Timber.i("Synced!")
+    }
+
+    /**
+     * Update sharedDataDir and userDataDir.
+     */
+    override fun onDataDirectoryChange() {
+        sharedDataDir = File(prefs.profile.sharedDataDir)
+        userDataDir = File(prefs.profile.userDataDir)
     }
 }

--- a/app/src/main/java/com/osfans/trime/data/opencc/OpenCCDictManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/opencc/OpenCCDictManager.kt
@@ -1,5 +1,6 @@
 package com.osfans.trime.data.opencc
 
+import com.osfans.trime.data.DataDirectoryChangeListener
 import com.osfans.trime.data.DataManager
 import com.osfans.trime.data.opencc.dict.Dictionary
 import com.osfans.trime.data.opencc.dict.OpenCCDictionary
@@ -10,13 +11,23 @@ import java.io.File
 import java.io.InputStream
 import kotlin.system.measureTimeMillis
 
-object OpenCCDictManager {
+object OpenCCDictManager : DataDirectoryChangeListener.Listener {
     init {
         System.loadLibrary("rime_jni")
+        // register listener
+        DataDirectoryChangeListener.addDirectoryChangeListener(this)
     }
 
-    val sharedDir = File(DataManager.sharedDataDir, "opencc").also { it.mkdirs() }
-    val userDir = File(DataManager.userDataDir, "opencc").also { it.mkdirs() }
+    var sharedDir = File(DataManager.sharedDataDir, "opencc").also { it.mkdirs() }
+    var userDir = File(DataManager.userDataDir, "opencc").also { it.mkdirs() }
+
+    /**
+     * Update sharedDir and userDir.
+     */
+    override fun onDataDirectoryChange() {
+        sharedDir = File(DataManager.sharedDataDir, "opencc").also { it.mkdirs() }
+        userDir = File(DataManager.userDataDir, "opencc").also { it.mkdirs() }
+    }
 
     fun sharedDictionaries(): List<Dictionary> = sharedDir
         .listFiles()

--- a/app/src/main/java/com/osfans/trime/data/sound/SoundThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/sound/SoundThemeManager.kt
@@ -3,13 +3,26 @@ package com.osfans.trime.data.sound
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.DataDirectoryChangeListener
 import com.osfans.trime.data.DataManager
 import timber.log.Timber
 import java.io.File
 
-object SoundThemeManager {
+object SoundThemeManager : DataDirectoryChangeListener.Listener {
 
-    val userDir = File(DataManager.userDataDir, "sound")
+    var userDir = File(DataManager.userDataDir, "sound")
+
+    init {
+        // register listener
+        DataDirectoryChangeListener.addDirectoryChangeListener(this)
+    }
+
+    /**
+     * Update userDir.
+     */
+    override fun onDataDirectoryChange() {
+        userDir = File(DataManager.userDataDir, "sound")
+    }
 
     private val yaml = Yaml(
         configuration = YamlConfiguration(

--- a/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
+++ b/app/src/main/java/com/osfans/trime/data/theme/ThemeManager.kt
@@ -1,10 +1,16 @@
 package com.osfans.trime.data.theme
 
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.DataDirectoryChangeListener
 import com.osfans.trime.data.DataManager
 import java.io.File
 
-object ThemeManager {
+object ThemeManager : DataDirectoryChangeListener.Listener {
+
+    init {
+        // register listener
+        DataDirectoryChangeListener.addDirectoryChangeListener(this)
+    }
 
     private fun listThemes(path: File): MutableList<String> {
         return path.listFiles { _, name -> name.endsWith("trime.yaml") }
@@ -18,13 +24,20 @@ object ThemeManager {
         AppPrefs.defaultInstance().themeAndColor.selectedTheme = theme
     }
 
-    val sharedThemes: MutableList<String> = listThemes(DataManager.sharedDataDir)
+    var sharedThemes: MutableList<String> = listThemes(DataManager.sharedDataDir)
 
-    val userThemes: MutableList<String> = listThemes(DataManager.userDataDir)
+    var userThemes: MutableList<String> = listThemes(DataManager.userDataDir)
 
     private lateinit var currentThemeName: String
 
-    @JvmStatic
+    /**
+     * Update sharedThemes and userThemes.
+     */
+    override fun onDataDirectoryChange() {
+        sharedThemes = listThemes(DataManager.sharedDataDir)
+        userThemes = listThemes(DataManager.userDataDir)
+    }
+
     fun init() {
         currentThemeName = AppPrefs.defaultInstance().themeAndColor.selectedTheme
     }

--- a/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/PrefMainActivity.kt
@@ -23,6 +23,7 @@ import com.hjq.permissions.XXPermissions
 import com.osfans.trime.R
 import com.osfans.trime.core.Rime
 import com.osfans.trime.data.AppPrefs
+import com.osfans.trime.data.DataDirectoryChangeListener
 import com.osfans.trime.data.sound.SoundThemeManager
 import com.osfans.trime.databinding.ActivityPrefBinding
 import com.osfans.trime.ui.setup.SetupActivity
@@ -122,6 +123,12 @@ class PrefMainActivity : AppCompatActivity() {
                         Runtime.getRuntime().exec(arrayOf("logcat", "-c"))
                     }
                     withContext(Dispatchers.Default) {
+                        // All functions that implement the DirectoryChangeListener.Listener
+                        //   interface are called here.
+                        // To refresh directory settings.
+                        DataDirectoryChangeListener.directoryChangeListeners.forEach {
+                            it.onDataDirectoryChange()
+                        }
                         Rime.deploy()
                     }
                     briefResultLogDialog("rime.trime", "W", 1)


### PR DESCRIPTION
When a user changes the shared data directory or the user data directory, use the `DataDirectoryChangeListener` to update the data directory on time.

## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #

#### Feature
Describe features of pull request

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

