### PR TITLE
fix: update tab manager when theme changes

### DIFF
--- a/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/LiquidKeyboard.kt
@@ -30,7 +30,6 @@ import timber.log.Timber
 
 class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboardUpdateListener {
     private val theme: Theme = Theme.get()
-    private val tabManager: TabManager = TabManager.get()
     private val service: Trime = Trime.getService()
     private lateinit var keyboardView: RecyclerView
     private val symbolHistory = SymbolHistory(180)
@@ -75,18 +74,18 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
             SymbolKeyboardType.COLLECTION,
             SymbolKeyboardType.DRAFT,
             -> {
-                tabManager.select(i)
+                TabManager.get().select(i)
                 initDbData(tag.type)
             }
             SymbolKeyboardType.CANDIDATE -> {
-                tabManager.select(i)
+                TabManager.get().select(i)
                 initCandidates()
             }
             SymbolKeyboardType.VAR_LENGTH -> {
-                initVarLengthKeys(tabManager.select(i))
+                initVarLengthKeys(TabManager.get().select(i))
             }
             SymbolKeyboardType.SYMBOL, SymbolKeyboardType.HISTORY, SymbolKeyboardType.TABS -> {
-                tabManager.select(i)
+                TabManager.get().select(i)
                 initFixData(i)
             }
             else -> initFixData(i)
@@ -112,8 +111,8 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
                         }
                     }
                 } else {
-                    val tag = tabManager.getTabSwitchTabTag(position)
-                    val truePosition = tabManager.getTabSwitchPosition(position)
+                    val tag = TabManager.get().getTabSwitchTabTag(position)
+                    val truePosition = TabManager.get().getTabSwitchPosition(position)
                     Timber.v(
                         "TABS click: " +
                             "position = $position, truePosition = $truePosition, tag.text = ${tag.text}",
@@ -124,7 +123,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
                             KeyCommandType.DEL_LEFT, KeyCommandType.DEL_RIGHT, KeyCommandType.REDO, KeyCommandType.UNDO -> {}
                             else -> {}
                         }
-                    } else if (tabManager.isAfterTabSwitch(truePosition)) {
+                    } else if (TabManager.get().isAfterTabSwitch(truePosition)) {
                         // tab的位置在“更多”的右侧，不滚动tab，焦点仍然在”更多“上
                         select(truePosition)
                     } else {
@@ -153,11 +152,11 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
             SymbolKeyboardType.HISTORY ->
                 simpleAdapter.updateBeans(symbolHistory.toOrderedList().map(::SimpleKeyBean))
             SymbolKeyboardType.TABS -> {
-                simpleAdapter.updateBeans(tabManager.tabSwitchData)
-                Timber.v("All tags in TABS: tabManager.tabSwitchData = ${tabManager.tabSwitchData}")
+                simpleAdapter.updateBeans(TabManager.get().tabSwitchData)
+                Timber.v("All tags in TABS: TabManager.get().tabSwitchData = ${TabManager.get().tabSwitchData}")
             }
             else ->
-                simpleAdapter.updateBeans(tabManager.select(i))
+                simpleAdapter.updateBeans(TabManager.get().select(i))
         }
         Timber.d("Tab #%s with bean size %s", i, simpleAdapter.itemCount)
     }
@@ -309,7 +308,7 @@ class LiquidKeyboard(private val context: Context) : ClipboardHelper.OnClipboard
      * 当剪贴板内容变化且剪贴板视图处于开启状态时，更新视图.
      */
     override fun onUpdate(text: String) {
-        val selected = tabManager.selected
+        val selected = TabManager.get().selected
         // 判断液体键盘视图是否已开启，-1为未开启
         if (selected >= 0) {
             val tag = TabManager.getTag(selected)

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabManager.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+// 使用TabManager时，不应该使用变量保存TabManager实例，应该使用TabManager.get()方法获取
 public class TabManager {
   private int selected = 0;
   private final List<SimpleKeyBean> keyboardData = new ArrayList<>();
@@ -20,6 +21,10 @@ public class TabManager {
   private static TabManager self;
   private final List<SimpleKeyBean> notKeyboard = new ArrayList<>();
   private final TabTag tagExit = new TabTag("返回", SymbolKeyboardType.NO_KEY, KeyCommandType.EXIT);
+
+  public static void updateSelf() {
+    self = new TabManager();
+  }
 
   public static TabManager get() {
     if (null == self) self = new TabManager();
@@ -192,8 +197,8 @@ public class TabManager {
   }
 
   public List<SimpleKeyBean> select(int tabIndex) {
-    if (tabIndex >= tabTags.size()) return keyboardData;
     selected = tabIndex;
+    if (tabIndex >= tabTags.size()) return keyboardData;
     TabTag tag = tabTags.get(tabIndex);
     if (tag.type == SymbolKeyboardType.TABS) tabSwitchPosition = selected;
     return keyboards.get(tabIndex);
@@ -201,6 +206,10 @@ public class TabManager {
 
   public int getSelected() {
     return selected;
+  }
+
+  public int getSelectedOrZero() {
+    return (selected == -1) ? 0 : selected;
   }
 
   public void setTabExited() {

--- a/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
+++ b/app/src/main/java/com/osfans/trime/ime/symbol/TabView.java
@@ -149,7 +149,7 @@ public class TabView extends View {
 
   public void updateTabWidth() {
     tabTags = TabManager.get().getTabCandidates();
-    highlightIndex = TabManager.get().getSelected();
+    highlightIndex = TabManager.get().getSelectedOrZero();
 
     int x = 0;
     for (TabTag computedTab : tabTags) {

--- a/app/src/main/java/com/osfans/trime/ui/main/Pickers.kt
+++ b/app/src/main/java/com/osfans/trime/ui/main/Pickers.kt
@@ -14,6 +14,7 @@ import com.osfans.trime.data.sound.SoundThemeManager
 import com.osfans.trime.data.theme.Theme
 import com.osfans.trime.data.theme.ThemeManager
 import com.osfans.trime.ime.core.Trime
+import com.osfans.trime.ime.symbol.TabManager
 import com.osfans.trime.ui.components.CoroutineChoiceDialog
 import com.osfans.trime.util.ProgressBarDialogIndeterminate
 import kotlinx.coroutines.Dispatchers
@@ -40,6 +41,7 @@ suspend fun Context.themePicker(
             with(items[checkedItem].toString()) {
                 ThemeManager.switchTheme(if (this == "trime") this else "$this.trime")
                 Theme.get().init()
+                TabManager.updateSelf()
             }
             launch {
                 Trime.getServiceOrNull()?.initKeyboard()


### PR DESCRIPTION
+ When changing themes, call the new method `updateSelf`. It will update liquid keyboard Tabs.
+ When using `TabManager` , you should not store a `TabManager` instance in a variable, but should instead use the `TabManager.get()` method to get it.

## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #

#### Feature
Describe features of pull request

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

